### PR TITLE
Run SteamCMD under its own user account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM debian:stretch-slim
 
-MAINTAINER Rocky Breslow <breslowrocky@gmail.com>
+LABEL maintainer="Rocky Breslow <breslowrocky@gmail.com>"
+
+RUN \
+   adduser --system --disabled-password --home /var/lib/steam --shell /sbin/nologin --disabled-password --group steam
 
 ENV DEBIAN_FRONTEND "noninteractive"
 
@@ -9,13 +12,17 @@ RUN echo "deb http://deb.debian.org/debian stretch non-free" > /etc/apt/sources.
 
 # Install `steamcmd` and agree to interactive license
 RUN set -ex \
-    && deps=" \
-       ca-certificates \
-       steamcmd \
-    " \
-     && dpkg --add-architecture i386 \
-     && echo steam steam/question select "I AGREE" | debconf-set-selections \
-     && apt-get update && apt-get install -y $deps --no-install-recommends \
-     && rm -rf /var/lib/apt/lists/*
-     
+   && deps=" \
+   ca-certificates \
+   steamcmd \
+   " \
+   && dpkg --add-architecture i386 \
+   && echo steam steam/question select "I AGREE" | debconf-set-selections \
+   && apt-get update && apt-get install -y $deps --no-install-recommends \
+   && rm -rf /var/lib/apt/lists/*
+
+USER steam
+WORKDIR /var/lib/steam
+
 ENTRYPOINT ["/usr/games/steamcmd"]
+CMD ["+login", "anonymous"]

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Rocky Breslow
+   Copyright 2019 Rocky Breslow
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# docker-steamcmd
+# docker-steamcmd ![Travis (.org)](https://img.shields.io/travis/rbreslow/docker-steamcmd)
 
 This repository contains a `Dockerfile` designed to support installing and updating various dedicated servers available on Steam using [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD).
 
@@ -7,13 +7,13 @@ This repository contains a `Dockerfile` designed to support installing and updat
 First, build the container image with:
 
 ```bash
-$ docker build -t quay.io/rbreslow/steamcmd:slim .
+docker build -t quay.io/rbreslow/steamcmd:slim .
 ```
 
 Then, create an instance of the container image:
 
 ```bash
-$ docker run --rm -ti --volume /tmp/css_ds:/root/css_ds quay.io/rbreslow/steamcmd
+$ docker run --rm -ti --volume /tmp/css_ds:/var/lib/steam/css_ds quay.io/rbreslow/steamcmd:slim
 ...
 Steam Console Client (c) Valve Corporation
 -- type 'quit' to exit --
@@ -30,7 +30,7 @@ Steam>login anonymous
 Connecting anonymously to Steam Public...Logged in OK
 Waiting for user info...OK
 
-Steam>force_install_dir /root/css_ds
+Steam>force_install_dir /var/lib/steam/css_ds
 
 Steam>app_update 232330
 ...
@@ -52,5 +52,5 @@ platform                   thirdpartylegalnotices.txt
 An example of how to use `cibuild` to build and test an image:
 
 ```bash
-$ CI=1 ./scripts/cibuild
+CI=1 ./scripts/cibuild
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# docker-steamcmd [![Travis (.org) branch](https://img.shields.io/travis/rbreslow/docker-steamcmd/master)](http://travis-ci.org/rbreslow/docker-steamcmd) [![quay.io](https://img.shields.io/badge/quay.io-slim-blue)](https://quay.io/repository/rbreslow/steamcmd)
+# docker-steamcmd [![Travis (.org) branch](https://img.shields.io/travis/rbreslow/docker-steamcmd/master)](http://travis-ci.org/rbreslow/docker-steamcmd) [![Docker Repository on Quay](https://quay.io/repository/rbreslow/steamcmd/status "Docker Repository on Quay")](https://quay.io/repository/rbreslow/steamcmd)
 
 This repository contains a `Dockerfile` designed to support installing and updating various dedicated servers available on Steam using [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# docker-steamcmd ![Travis (.org)](https://img.shields.io/travis/rbreslow/docker-steamcmd)
+# docker-steamcmd [![Travis (.org) branch](https://img.shields.io/travis/rbreslow/docker-steamcmd/master)](http://travis-ci.org/rbreslow/docker-steamcmd) [![quay.io](https://img.shields.io/badge/quay.io-slim-blue)](https://quay.io/repository/rbreslow/steamcmd)
 
 This repository contains a `Dockerfile` designed to support installing and updating various dedicated servers available on Steam using [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD).
 

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -9,7 +9,7 @@ fi
 
 function usage() {
     echo -n \
-"Usage: $(basename "$0")
+        "Usage: $(basename "$0")
 Build container images from templates.
 "
 }

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -5,7 +5,7 @@ set -u
 
 function usage() {
     echo -n \
-"Usage: $(basename "$0")
+        "Usage: $(basename "$0")
 Publish container images built from templates.
 "
 }
@@ -15,7 +15,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         usage
     else
         docker \
-            login -u "${QUAY_USER}" -p "${QUAY_PASSWORD}" quay.io;
+            login -u "${QUAY_USER}" -p "${QUAY_PASSWORD}" quay.io
 
         docker \
             push "quay.io/rbreslow/steamcmd:slim"

--- a/scripts/test
+++ b/scripts/test
@@ -9,7 +9,7 @@ fi
 
 function usage() {
     echo -n \
-"Usage: $(basename "$0")
+        "Usage: $(basename "$0")
 Test container images built from templates.
 "
 }


### PR DESCRIPTION
## Overview

Valve [recommends](https://developer.valvesoftware.com/wiki/SteamCMD#Linux) running SteamCMD under its own `steam` user account. Additionally, SRCDS will throw a warning if ran as `root`.

- Configure dependent images to run under `steam` (with [`USER`](https://docs.docker.com/engine/reference/#user) block)
- Update README to reflect path changes
- Run [shfmt](https://github.com/mvdan/sh)

Resolves #1 

## Testing Instructions



Execute `cibuild` and see the following output:

```bash
$ CI=1 ./scripts/cibuild
...
Steam Console Client (c) Valve Corporation
-- type 'quit' to exit --
Loading Steam API...OK.
Account:
SteamID: [U:1:0]
Email:
Logon state: Logged Off
Language: english

Persona Name:
Persona State: Offline
Direct Friends: 0
Groups Friends: 0

InstallPath: /var/lib/steam/.steam/steamcmd/linux32
Universe: Public
Server Time: Fri Sep  6 18:26:55 2019
IPCountry:
Offline Mode: no
CellID: 0
```

Clone [docker-garrysmodds](https://github.com/rbreslow/docker-garrysmodds/) and checkout `jrb/run-as-steam-user`:

```bash
git clone https://github.com/rbreslow/docker-garrysmodds/
git checkout jrb/run-as-steam-user
git pull
```

Run `cibuild` to build docker-garrysmodds off this PR branch:

```bash
CI=1 ./scripts/cibuild
```

Start SRCDS and confirm the deprecation notice is gone:

```bash
$ docker run -ti \
    -p 27015:27015 \
    -p 27015:27015/udp \
    --rm quay.io/rbreslow/garrysmodds:slim
Auto detecting CPU
Using default binary: ./srcds_linux
Server will auto-restart if there is a crash.
Couldn't load shader dll: game_shader_generic_garrysmod_srv.soConVarRef mat_dxlevel doesn't point to an existing ConVar
Game_srv.so loaded for "Garry's Mod"
Setting breakpad minidump AppID = 4000
Initializing Steam libraries for Workshop..
...
```