### PR TITLE
Add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# docker-steamcmd [![CI](https://github.com/rbreslow/docker-steamcmd/workflows/CI/badge.svg?branch=master)](https://github.com/rbreslow/docker-steamcmd/actions?query=workflow%3ACI) [![Docker Repository on Quay](https://quay.io/repository/rbreslow/steamcmd/status "Docker Repository on Quay")](https://quay.io/repository/rbreslow/steamcmd)
+# docker-steamcmd [![CI](https://github.com/rbreslow/docker-steamcmd/workflows/CI/badge.svg?branch=master)](https://github.com/rbreslow/docker-steamcmd/actions?query=workflow%3ACI)
 
 This repository contains a `Dockerfile` designed to support installing and updating various dedicated servers available on Steam using [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD).
 
@@ -6,15 +6,17 @@ This repository contains a `Dockerfile` designed to support installing and updat
 
 First, build the container image with:
 
-```bash
-docker build -t quay.io/rbreslow/steamcmd:slim .
+```console
+$ docker build -t quay.io/rbreslow/steamcmd:slim .
 ```
 
 Then, create an instance of the container image:
 
-```bash
-$ docker run --rm -ti --volume /tmp/css_ds:/var/lib/steam/css_ds quay.io/rbreslow/steamcmd:slim
-...
+```console
+$ docker run --rm -it --volume /tmp/css_ds:/var/lib/steam/css_ds quay.io/rbreslow/steamcmd:slim
+
+. . .
+
 Steam Console Client (c) Valve Corporation
 -- type 'quit' to exit --
 Loading Steam API...OK.
@@ -24,7 +26,7 @@ Steam>
 
 Login anonymously and download Counter-Strike: Source DS:
 
-```bash
+```console
 Steam>login anonymous
 
 Connecting anonymously to Steam Public...Logged in OK
@@ -33,13 +35,15 @@ Waiting for user info...OK
 Steam>force_install_dir /var/lib/steam/css_ds
 
 Steam>app_update 232330
-...
+
+. . .
+
 Success! App '232330' fully installed.
 ```
 
 Detach from the container and test:
 
-```
+```console
 $ ls /tmp/css_ds
 bin                        srcds_linux
 cstrike                    srcds_run
@@ -51,6 +55,6 @@ platform                   thirdpartylegalnotices.txt
 
 An example of how to use `cibuild` to build and test an image:
 
-```bash
-CI=1 ./scripts/cibuild
+```console
+$ CI=1 ./scripts/cibuild
 ```


### PR DESCRIPTION
I set up a Zapier action to listen to the [Steam RSS News Feed](https://store.steampowered.com/feeds/), [filtered](https://siftrss.com/) to new Steam Client updates. This pull request adds the `workflow_dispatch` trigger so that Zapier can invoke the workflow.

Resolves #2 

---

**Testing**

See passing checks below.